### PR TITLE
Fix NoSuchMethod error when using Create 0.3.2f+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ forge_version=36.2.0
 create_file_id=3499718
 flywheel_version=1.16-0.2.3.44
 
-mod_version=1.1.2
+mod_version=1.1.3
 modid=createdeco
 author=talrey
 display_name = Create Deco

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.daemon=false
 # Versions
 minecraft_version=1.16.5
 forge_version=36.2.0
-create_file_id=3406857
-flywheel_version=1.16-0.2.0.35
+create_file_id=3499718
+flywheel_version=1.16-0.2.3.44
 
 mod_version=1.1.2
 modid=createdeco

--- a/src/main/java/com/github/talrey/createdeco/connected/CDCTSpriteShifter.java
+++ b/src/main/java/com/github/talrey/createdeco/connected/CDCTSpriteShifter.java
@@ -9,12 +9,12 @@ import net.minecraft.util.ResourceLocation;
 public class CDCTSpriteShifter extends SpriteShifter {
   public static CTSpriteShiftEntry getCT (CTType type, ResourceLocation blockTexture, String connectedTexture) {
     String key = type.name() + ":" + blockTexture.getNamespace() + ":" + blockTexture.getPath() + "->" + connectedTexture;
-    if (textures.containsKey(key)) {
-      return (CTSpriteShiftEntry) textures.get(key);
+    if (ENTRY_CACHE.containsKey(key)) {
+      return (CTSpriteShiftEntry) ENTRY_CACHE.get(key);
     }
     CTSpriteShiftEntry entry = create(type);
     entry.set(blockTexture, new ResourceLocation(CreateDecoMod.MODID, connectedTexture));
-    textures.put(key, entry);
+    ENTRY_CACHE.put(key, entry);
     return entry;
   }
 

--- a/src/main/java/com/github/talrey/createdeco/connected/SpriteShifts.java
+++ b/src/main/java/com/github/talrey/createdeco/connected/SpriteShifts.java
@@ -2,6 +2,7 @@ package com.github.talrey.createdeco.connected;
 
 import com.github.talrey.createdeco.CreateDecoMod;
 import com.github.talrey.createdeco.Registration;
+import com.simibubi.create.Create;
 import com.simibubi.create.foundation.block.connected.CTSpriteShiftEntry;
 import com.simibubi.create.foundation.block.connected.CTSpriteShifter;
 import com.simibubi.create.foundation.block.connected.CTSpriteShifter.CTType;
@@ -19,13 +20,15 @@ public class SpriteShifts {
 
   private static void populateMaps () {
     for (String metal : Registration.METAL_TYPES.keySet()) {
-      String path = "palettes/sheet_metal/" + metal.toLowerCase() + "_sheet_metal";
-      ResourceLocation blockTexture = new ResourceLocation(CreateDecoMod.MODID, "block/" + path);
-      SHEET_METAL_SIDES.put(metal, CTSpriteShifter.getCT(CTType.VERTICAL, blockTexture, path));
+      String path = "block/palettes/sheet_metal/" + metal.toLowerCase() + "_sheet_metal";
+      ResourceLocation blockTexture = new ResourceLocation(CreateDecoMod.MODID, path);
+      ResourceLocation connectedTexture = new ResourceLocation(Create.ID, path + "_connected");
+      SHEET_METAL_SIDES.put(metal, CTSpriteShifter.getCT(CTType.VERTICAL, blockTexture, connectedTexture));
 
-      path = "palettes/catwalks/" + metal.toLowerCase() + "_catwalk";
-      blockTexture = new ResourceLocation(CreateDecoMod.MODID, "block/" + path);
-      CATWALK_TOPS.put(metal, CTSpriteShifter.getCT(CTType.OMNIDIRECTIONAL, blockTexture, path));
+      path = "block/palettes/catwalks/" + metal.toLowerCase() + "_catwalk";
+      blockTexture = new ResourceLocation(CreateDecoMod.MODID, path);
+      connectedTexture = new ResourceLocation(Create.ID, path + "_connected");
+      CATWALK_TOPS.put(metal, CTSpriteShifter.getCT(CTType.OMNIDIRECTIONAL, blockTexture, connectedTexture));
     }
   }
 }

--- a/src/main/java/com/github/talrey/createdeco/connected/SpriteShifts.java
+++ b/src/main/java/com/github/talrey/createdeco/connected/SpriteShifts.java
@@ -22,12 +22,12 @@ public class SpriteShifts {
     for (String metal : Registration.METAL_TYPES.keySet()) {
       String path = "block/palettes/sheet_metal/" + metal.toLowerCase() + "_sheet_metal";
       ResourceLocation blockTexture = new ResourceLocation(CreateDecoMod.MODID, path);
-      ResourceLocation connectedTexture = new ResourceLocation(Create.ID, path + "_connected");
+      ResourceLocation connectedTexture = Create.asResource(path + "_connected");
       SHEET_METAL_SIDES.put(metal, CTSpriteShifter.getCT(CTType.VERTICAL, blockTexture, connectedTexture));
 
       path = "block/palettes/catwalks/" + metal.toLowerCase() + "_catwalk";
       blockTexture = new ResourceLocation(CreateDecoMod.MODID, path);
-      connectedTexture = new ResourceLocation(Create.ID, path + "_connected");
+      connectedTexture = Create.asResource(path + "_connected");
       CATWALK_TOPS.put(metal, CTSpriteShifter.getCT(CTType.OMNIDIRECTIONAL, blockTexture, connectedTexture));
     }
   }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -61,6 +61,6 @@ Adds several varieties of decorative blocks to fill out Create's palette.
 [[dependencies.createdeco]]
     modId="create"
     mandatory=true
-    versionRange="[mc1.16.5_v0.3.1c,)"
+    versionRange="[mc1.16.5_v0.3.1f,)"
     ordering="AFTER"
     side="BOTH"


### PR DESCRIPTION
- Updated Create dependency to 0.3.2f
- Updated CDCTSpriteShifer to use renamed "textures" -> "ENTRY_CACHE"
- Updated SpriteShifts to use new `getCT(CTType,ResourceLocation,ResourceLocation)` signature.

Fixes #2 