### PR TITLE
Provided a copy of NonNullSupplier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,7 @@ loom {
 dependencies {
     minecraft("com.mojang:minecraft:${project.minecraft_version}")
 
-    mappings loom.layered {
-        it.addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:1.18.2+build.22:v2")) // https://lambdaurora.dev/tools/import_quilt.html
-        it.parchment("org.parchmentmc.data:parchment-1.18.2:BLEEDING-20220313.132143-1@zip") // https://ldtteam.jfrog.io/ui/native/parchmentmc-public/org/parchmentmc/data/parchment-1.18.1/BLEEDING-SNAPSHOT
-        it.officialMojangMappings {
-            setNameSyntheticMembers(false)
-        }
-    }
+    mappings loom.officialMojangMappings()
     modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
 
     modImplementation("com.simibubi:Create:mc${create_version}")

--- a/src/main/java/com/github/talrey/createdeco/registry/Props.java
+++ b/src/main/java/com/github/talrey/createdeco/registry/Props.java
@@ -6,7 +6,7 @@ import com.github.talrey.createdeco.blocks.CageLampBlock;
 import com.github.talrey.createdeco.blocks.CoinStackBlock;
 import com.github.talrey.createdeco.blocks.DecalBlock;
 import com.github.talrey.createdeco.items.CoinStackItem;
-import com.jozufozu.flywheel.util.NonNullSupplier;
+import com.github.talrey.createdeco.util.NonNullSupplier;
 import com.mojang.math.Vector3f;
 import com.simibubi.create.AllItems;
 import com.tterrag.registrate.Registrate;

--- a/src/main/java/com/github/talrey/createdeco/registry/SheetMetal.java
+++ b/src/main/java/com/github/talrey/createdeco/registry/SheetMetal.java
@@ -7,7 +7,7 @@ import com.github.talrey.createdeco.connected.SheetMetalCTBehaviour;
 import com.github.talrey.createdeco.connected.SheetMetalSlabCTBehaviour;
 import com.github.talrey.createdeco.connected.SheetMetalVertCTBehaviour;
 import com.github.talrey.createdeco.connected.SpriteShifts;
-import com.jozufozu.flywheel.util.NonNullSupplier;
+import com.github.talrey.createdeco.util.NonNullSupplier;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.tterrag.registrate.Registrate;

--- a/src/main/java/com/github/talrey/createdeco/util/NonNullSupplier.java
+++ b/src/main/java/com/github/talrey/createdeco/util/NonNullSupplier.java
@@ -1,0 +1,9 @@
+package com.github.talrey.createdeco.util;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface NonNullSupplier<T> {
+
+	@Nonnull T get();
+}


### PR DESCRIPTION
To avoid relying on the Flywheel version, which isn't available on the server.

This way current 1.18.2 builds ought work again.

Also updated mappings to Mojang default because that was what Create does and it is the only way I could get it to build. (No clue what the actual difference is, I am not familiar Minecraft modding by any means.)