### PR TITLE
Fixed Non ore dict zinc ingot and block recipes

### DIFF
--- a/src/generated/resources/data/createdeco/recipes/zinc_bars.json
+++ b/src/generated/resources/data/createdeco/recipes/zinc_bars.json
@@ -1,16 +1,16 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "mmm",
-    "mmm"
-  ],
-  "key": {
-    "m": {
-      "item": "create:zinc_ingot"
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "mmm",
+        "mmm"
+    ],
+    "key": {
+        "m": {
+            "tag": "forge:ingots/zinc"
+        }
+    },
+    "result": {
+        "item": "createdeco:zinc_bars",
+        "count": 16
     }
-  },
-  "result": {
-    "item": "createdeco:zinc_bars",
-    "count": 16
-  }
 }

--- a/src/generated/resources/data/createdeco/recipes/zinc_door.json
+++ b/src/generated/resources/data/createdeco/recipes/zinc_door.json
@@ -1,16 +1,16 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "mm",
-    "mm",
-    "mm"
-  ],
-  "key": {
-    "m": {
-      "item": "create:zinc_ingot"
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "mm",
+        "mm",
+        "mm"
+    ],
+    "key": {
+        "m": {
+            "tag": "forge:ingots/zinc"
+        }
+    },
+    "result": {
+        "item": "createdeco:zinc_door"
     }
-  },
-  "result": {
-    "item": "createdeco:zinc_door"
-  }
 }

--- a/src/generated/resources/data/createdeco/recipes/zinc_sheet_metal_from_zinc_block_stonecutting.json
+++ b/src/generated/resources/data/createdeco/recipes/zinc_sheet_metal_from_zinc_block_stonecutting.json
@@ -1,8 +1,8 @@
 {
-  "type": "minecraft:stonecutting",
-  "ingredient": {
-    "item": "create:zinc_block"
-  },
-  "result": "createdeco:zinc_sheet_metal",
-  "count": 4
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "tag": "forge:storage_blocks/zinc"
+    },
+    "result": "createdeco:zinc_sheet_metal",
+    "count": 4
 }

--- a/src/generated/resources/data/minecraft/recipes/pressing/zinc_sheet.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/zinc_sheet.json
@@ -1,13 +1,9 @@
 {
-  "type": "create:pressing",
-  "ingredients": [
-    {
-      "item": "create:zinc_ingot"
-    }
-  ],
-  "results": [
-    {
-      "item": "createdeco:zinc_sheet"
-    }
-  ]
+    "type": "create:pressing",
+    "ingredients": [{
+        "tag": "forge:ingots/zinc"
+    }],
+    "results": [{
+        "item": "createdeco:zinc_sheet"
+    }]
 }


### PR DESCRIPTION
Changed recipes that use specifically create zin ingots and blocks to use the forge tag
and indentation got changed (thanks VSCode)