### PR TITLE
BugFix: Coin recipe is enabled even when the config file "can_press_coins = false"

### DIFF
--- a/src/generated/resources/data/minecraft/recipes/pressing/brass_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/brass_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/brass"

--- a/src/generated/resources/data/minecraft/recipes/pressing/cast_iron_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/cast_iron_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/cast_iron"

--- a/src/generated/resources/data/minecraft/recipes/pressing/copper_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/copper_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/copper"

--- a/src/generated/resources/data/minecraft/recipes/pressing/gold_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/gold_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/gold"

--- a/src/generated/resources/data/minecraft/recipes/pressing/iron_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/iron_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/iron"

--- a/src/generated/resources/data/minecraft/recipes/pressing/netherite_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/netherite_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/netherite"

--- a/src/generated/resources/data/minecraft/recipes/pressing/zinc_coin.json
+++ b/src/generated/resources/data/minecraft/recipes/pressing/zinc_coin.json
@@ -1,5 +1,11 @@
 {
   "type": "create:pressing",
+  "conditions": [
+    {
+      "type": "createdeco:config",
+      "config": "can_press_coins"
+    }
+  ],
   "ingredients": [
     {
       "tag": "forge:nuggets/zinc"

--- a/src/main/java/com/github/talrey/createdeco/Config.java
+++ b/src/main/java/com/github/talrey/createdeco/Config.java
@@ -17,14 +17,14 @@ public class Config {
   public static ForgeConfigSpec COMMON_CONF, CLIENT_CONF;
 
   public static HashMap<String, ForgeConfigSpec.ConfigValue<?>> SETTINGS = new HashMap<>();
-  //public static String CAN_PRESS_COINS = "can_press_coins";
+  public static String CAN_PRESS_COINS = "can_press_coins";
 
   static {
     ForgeConfigSpec.Builder COMMON = new ForgeConfigSpec.Builder();
     ForgeConfigSpec.Builder CLIENT = new ForgeConfigSpec.Builder();
 
     COMMON.comment("General Settings").push(CAT_GENERAL);
-    //SETTINGS.put(CAN_PRESS_COINS, COMMON.comment("allow coin recipe").define(CAN_PRESS_COINS, true));
+    SETTINGS.put(CAN_PRESS_COINS, COMMON.comment("allow coin recipe").define(CAN_PRESS_COINS, false));
     COMMON.pop();
 
     COMMON_CONF = COMMON.build();

--- a/src/main/java/com/github/talrey/createdeco/ConfigCondition.java
+++ b/src/main/java/com/github/talrey/createdeco/ConfigCondition.java
@@ -12,7 +12,7 @@ public class ConfigCondition implements ICondition {
   public static final ResourceLocation NAME = new ResourceLocation(CreateDecoMod.MODID, "config");
   private final String configName;
 
-  public static final RecipeSerializer<Recipe<?>> SERIALZIER = null;
+  public static final RecipeSerializer<Recipe<?>> SERIALIZER = null;
 
   public ConfigCondition (String name) {
     configName = name;

--- a/src/main/java/com/github/talrey/createdeco/CreateDecoMod.java
+++ b/src/main/java/com/github/talrey/createdeco/CreateDecoMod.java
@@ -33,6 +33,8 @@ public class CreateDecoMod
     ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Config.CLIENT_CONF);
     ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONF);
 
+    CraftingHelper.register(new ConfigCondition.Serializer());
+
     MinecraftForge.EVENT_BUS.register(this);
 
     createDecoRegistrar = Registrate.create(MODID);

--- a/src/main/java/com/github/talrey/createdeco/PressingRecipes.java
+++ b/src/main/java/com/github/talrey/createdeco/PressingRecipes.java
@@ -26,6 +26,7 @@ public class PressingRecipes extends ProcessingRecipeWrapper<PressingRecipe> {
     Props.COIN_ITEM.forEach((metal, coin) ->
       add(metal.toLowerCase(Locale.ROOT).replaceAll(" ", "_") + "_coin",
         ts -> ts.require(Registration.makeItemTag("nuggets/" + metal.toLowerCase(Locale.ROOT).replaceAll(" ", "_")))
+          .withCondition(new ConfigCondition(Config.CAN_PRESS_COINS))
           .output(coin.get())
       )
     );


### PR DESCRIPTION
I notice that when copying the code from 1.18 the Create condition serializer was asserting while generating the data. This was because the config condition wasn't registered correctly.

Register ConfigCondition&Serializer.
Uncommented code from 1.18 branch
Add condition in Pressing coin recipes to follow the config file.


Fixed type (SERIALZIER -> SERIALIZER)