### PR TITLE
Make chainlink fences and catwalks translucent

### DIFF
--- a/common/src/main/java/com/github/talrey/createdeco/api/Catwalks.java
+++ b/common/src/main/java/com/github/talrey/createdeco/api/Catwalks.java
@@ -74,7 +74,7 @@ public class Catwalks {
         supportPool.add(supports);
         table.add(block, builder.withPool(catwalksPool).withPool(supportPool));
       })
-      .addLayer(()-> RenderType::cutoutMipped)
+      .addLayer(()-> RenderType::translucent)
       .tag(BlockTags.MINEABLE_WITH_PICKAXE)
       .tag(AllTags.AllBlockTags.FAN_TRANSPARENT.tag)
       .item(CatwalkBlockItem::new)
@@ -129,7 +129,7 @@ public class Catwalks {
         stairsPool.add(stairs);
         table.add(block, builder.withPool(stairsPool).withPool(railingsPool));
       })
-      .addLayer(()-> RenderType::cutoutMipped)
+      .addLayer(()-> RenderType::translucent)
       .tag(BlockTags.MINEABLE_WITH_PICKAXE)
       .tag(AllTags.AllBlockTags.FAN_TRANSPARENT.tag)
       .blockstate((ctx,prov)-> BlockStateGenerator.catwalkStair(texture, ctx, prov))
@@ -146,7 +146,7 @@ public class Catwalks {
         props.strength(5, (metal.equals("Netherite")) ? 1200 : 6)
           .requiresCorrectToolForDrops().noOcclusion().sound(SoundType.NETHERITE_BLOCK)
       )
-      .addLayer(()-> RenderType::cutoutMipped)
+      .addLayer(()-> RenderType::translucent)
       .tag(BlockTags.MINEABLE_WITH_PICKAXE)
       .tag(AllTags.AllBlockTags.FAN_TRANSPARENT.tag)
       .blockstate((ctx,prov)-> BlockStateGenerator.catwalkRailing(reg, metal, ctx, prov))

--- a/common/src/main/java/com/github/talrey/createdeco/api/MeshFences.java
+++ b/common/src/main/java/com/github/talrey/createdeco/api/MeshFences.java
@@ -39,7 +39,7 @@ public class MeshFences {
       .properties(props-> props.strength(5, (metal.equals("Netherite")) ? 1200 : 6).requiresCorrectToolForDrops()
         .sound(SoundType.CHAIN)
       )
-      .addLayer(()-> RenderType::cutoutMipped)
+      .addLayer(()-> RenderType::translucent)
       .tag(BlockTags.FENCES)
       .tag(BlockTags.MINEABLE_WITH_PICKAXE)
       .item()


### PR DESCRIPTION
<img width="1512" alt="image" src="https://github.com/talrey/CreateDeco/assets/3837797/65e012ea-b4e3-4311-a940-03309a90977b">

A trick I learned with KSP modding :)

It means that instead of getting opaque when the lower mipmaps are used, it just becomes 50% transparent. Looks a lot better at shallow angles, like this: (before and after)

<img width="214" alt="Screenshot 2024-02-11 at 10 50 24 PM" src="https://github.com/talrey/CreateDeco/assets/3837797/4f800240-a363-4dd6-9414-e55497b2d995">
<img width="175" alt="Screenshot 2024-02-11 at 10 57 22 PM" src="https://github.com/talrey/CreateDeco/assets/3837797/d4912c18-9219-4034-ba03-092339c317b0">
