### PR TITLE
Fix #143 by always using the root locale

### DIFF
--- a/common/src/main/java/com/github/talrey/createdeco/api/Windows.java
+++ b/common/src/main/java/com/github/talrey/createdeco/api/Windows.java
@@ -106,7 +106,7 @@ public class Windows {
 
   public static BlockEntry<ConnectedGlassPaneBlock> metalWindowPane(String metal,
                                                                      Supplier<? extends Block> parent, Supplier<Supplier<RenderType>> renderType) {
-    String name = metal.toLowerCase().replace(" ", "_") + "_window";
+    String name = metal.toLowerCase(Locale.ROOT).replace(" ", "_") + "_window";
     ResourceLocation topTexture = CreateDecoMod.id(palettesDir() + name + "_end");
     ResourceLocation sideTexture = CreateDecoMod.id(palettesDir() + name);
     return connectedGlassPane(name, parent, () -> SpriteShifts.METAL_WINDOWS.get(metal), sideTexture,


### PR DESCRIPTION
This pr fixes a crash when the computer uses the turkish locale by always using the root locale for lowercasing internal names.

See the comment on https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#toLowerCase() for more info about the problem.