### PR TITLE
Added Forge and Common Tags to certain items

### DIFF
--- a/common/src/main/resources/data/c/tags/items/andesite_plates.json
+++ b/common/src/main/resources/data/c/tags/items/andesite_plates.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:andesite_sheet"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/industrial_iron_ingots.json
+++ b/common/src/main/resources/data/c/tags/items/industrial_iron_ingots.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_ingot"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/industrial_iron_nuggets.json
+++ b/common/src/main/resources/data/c/tags/items/industrial_iron_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_nugget"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/industrial_iron_plates.json
+++ b/common/src/main/resources/data/c/tags/items/industrial_iron_plates.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_sheet"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/netherite_nuggets.json
+++ b/common/src/main/resources/data/c/tags/items/netherite_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:netherite_nugget"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/netherite_plates.json
+++ b/common/src/main/resources/data/c/tags/items/netherite_plates.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:netherite_sheet"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/zinc_plates.json
+++ b/common/src/main/resources/data/c/tags/items/zinc_plates.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:zinc_sheet"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/ingots/industrial_iron.json
+++ b/common/src/main/resources/data/forge/tags/items/ingots/industrial_iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_ingot"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/nuggets/industrial_iron.json
+++ b/common/src/main/resources/data/forge/tags/items/nuggets/industrial_iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_nugget"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/nuggets/netherite.json
+++ b/common/src/main/resources/data/forge/tags/items/nuggets/netherite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:netherite_nugget"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/plates/andesite_alloy.json
+++ b/common/src/main/resources/data/forge/tags/items/plates/andesite_alloy.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:andesite_sheet"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/plates/industrial_iron.json
+++ b/common/src/main/resources/data/forge/tags/items/plates/industrial_iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:industrial_iron_sheet"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/plates/netherite.json
+++ b/common/src/main/resources/data/forge/tags/items/plates/netherite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:netherite_sheet"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/plates/zinc.json
+++ b/common/src/main/resources/data/forge/tags/items/plates/zinc.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createdeco:zinc_sheet"
+  ]
+}


### PR DESCRIPTION
As the title says, I decided to add the following items to the Forge and Common Tags where applicable. This will introduce compatibility with many mods that add similar items. If the mod gets updated to 1.21.1, we can remove the Forge tags since all mod loaders use the Common tags, although it will need to be updated to better reflect the 1.21.1 standard

The following items are added to their respective tags:
- Plates: Andesite Alloy Sheet, Zinc Sheet, Netherite Sheet, Industrial Iron Sheet
- Nuggets: Netherite Nugget, Industrial Iron Nugget
- Ingots: Industrial Iron Ingot

If needed, I can add more items and blocks to fitting tags wherever they fit. Like I said, this should make the mod much more compatible with other mods without impacting the main mod itself and the stuff it adds (hopefully)