### PR TITLE
Add back Fabric support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,15 +25,15 @@ forge_version = 47.4.0
 
 # Create - Fabric
 # https://modrinth.com/mod/create-fabric/versions
-create_fabric_version =  6.0.0.0+mc1.20.1-build.1653
+create_fabric_version =  6.0.7.0+mc1.20.1-build.1716
 
 # Create - Forge
 # https://github.com/Creators-of-Create/Create/wiki/Depending-on-Create
-create_forge_version = 6.0.2-52
+create_forge_version = 6.0.7-281
 registrate_forge_version = MC1.20-1.3.11
 flywheel_forge_minecraft_version = 1.20.1
-flywheel_forge_version = 1.0.1
-ponder_forge_version = 1.0.51
+flywheel_forge_version = 1.0.5
+ponder_forge_version = 1.0.91
 
 # Development QOL
 # Create Fabric supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.


### PR DESCRIPTION
Minor tweak - Create Fabric has now released 6.0 and Create Deco can now update safely.