### PR TITLE
Fixed an instance of id instead of item in the placard recipe

### DIFF
--- a/src/main/resources/data/createdeco/recipe/placard.json
+++ b/src/main/resources/data/createdeco/recipe/placard.json
@@ -7,7 +7,7 @@
       "tag": "createdeco:placards"
     },
     {
-      "id": "minecraft:white_dye"
+      "item": "minecraft:white_dye"
     }
   ],
   "result": {


### PR DESCRIPTION
When updating the version of Create Deco in my pack after a break, KubeJS began complaining, again, about the placard recipe. Looks like there was at some point an extra change from "item: white_dye" to "id:white_dye" for ingredients: [ ].